### PR TITLE
Add gobject-introspection as dependency

### DIFF
--- a/Formula/goocanvas.rb
+++ b/Formula/goocanvas.rb
@@ -11,8 +11,8 @@ class Goocanvas < Formula
     sha256 "26d6c8d30f7a9056af03e59691a4112147cff745855042244413b83be99c7ae9" => :el_capitan
   end
 
-  depends_on "pkg-config" => :build
   depends_on "gobject-introspection" => :build
+  depends_on "pkg-config" => :build
   depends_on "cairo"
   depends_on "glib"
   depends_on "gtk+3"

--- a/Formula/goocanvas.rb
+++ b/Formula/goocanvas.rb
@@ -12,6 +12,7 @@ class Goocanvas < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "gobject-introspection" => :build
   depends_on "cairo"
   depends_on "glib"
   depends_on "gtk+3"


### PR DESCRIPTION
The build fails on ./configure that can not find gobject-introspection (via pkg-config) because it misses libffi which is keg-only.
